### PR TITLE
4.1

### DIFF
--- a/bitcraft_preview/config.py
+++ b/bitcraft_preview/config.py
@@ -15,10 +15,13 @@ DEFAULT_CONFIG = {
     "mode": "sandboxie",
     "UserSettings": {
         "inline_label": True,                 # Needs Restart
+        "overlay_enabled": True,              # Live
         "preview_opacity": 0.8,               # Live
         "hover_zoom_enabled": True,           # Live
         "hover_zoom_percent": 200,            # Live (100-500)
         "hide_active_window_overlay": False,  # Live
+        "show_overlay_only_when_focused": False,  # Live
+        "save_overlay_position_per_account": True,  # Live
         "switch_window_enabled": True,        # Live
         "switch_window_hotkey": "MOUSE5",    # Live
         "preview_tile_width": 300,            # Live
@@ -214,9 +217,14 @@ INLINE_LABEL = _current_config["UserSettings"]["inline_label"]
 
 # Real-time getters for settings that should be checked actively
 def get_preview_opacity(): return load_config()["UserSettings"]["preview_opacity"]
+def get_overlay_enabled(): return bool(load_config()["UserSettings"].get("overlay_enabled", True))
 def get_hover_zoom_enabled(): return load_config()["UserSettings"]["hover_zoom_enabled"]
 def get_hover_zoom_percent(): return load_config()["UserSettings"]["hover_zoom_percent"]
 def get_hide_active_window_overlay(): return load_config()["UserSettings"]["hide_active_window_overlay"]
+def get_show_overlay_only_when_focused():
+    return bool(load_config()["UserSettings"].get("show_overlay_only_when_focused", False))
+def get_save_overlay_position_per_account():
+    return bool(load_config()["UserSettings"].get("save_overlay_position_per_account", True))
 def get_switch_window_enabled():
     value = load_config()["UserSettings"].get("switch_window_enabled", True)
     if isinstance(value, bool):

--- a/bitcraft_preview/native/state_manager.py
+++ b/bitcraft_preview/native/state_manager.py
@@ -39,6 +39,8 @@ class NativeInstance:
     steam_exe_path: str = ""
     steamapps_link_path: str = ""
     steamapps_link_target: str = ""
+    tile_position_x: int = 0
+    tile_position_y: int = 0
     status: str = "provisioning"
 
 
@@ -132,6 +134,8 @@ class NativeModeStateManager:
         steam_exe_path: str | None = None,
         steamapps_link_path: str | None = None,
         steamapps_link_target: str | None = None,
+        tile_position_x: int | None = None,
+        tile_position_y: int | None = None,
         status: str | None = "ready",
     ) -> NativeInstance:
         cfg = self.load_config()
@@ -160,6 +164,8 @@ class NativeModeStateManager:
             steam_exe_path=existing.get("steam_exe_path", "") if steam_exe_path is None else steam_exe_path,
             steamapps_link_path=existing.get("steamapps_link_path", "") if steamapps_link_path is None else steamapps_link_path,
             steamapps_link_target=existing.get("steamapps_link_target", "") if steamapps_link_target is None else steamapps_link_target,
+            tile_position_x=int(existing.get("tile_position_x", 0)) if tile_position_x is None else int(tile_position_x),
+            tile_position_y=int(existing.get("tile_position_y", 0)) if tile_position_y is None else int(tile_position_y),
             status=existing.get("status", "provisioning") if status is None else status,
         )
 

--- a/bitcraft_preview/ui/overlay_manager.py
+++ b/bitcraft_preview/ui/overlay_manager.py
@@ -5,7 +5,19 @@ import ctypes
 import psutil
 from bitcraft_preview.win32.window_discovery import enumerate_windows
 from bitcraft_preview.ui.tile import LivePreviewTile
-from bitcraft_preview.config import PROCESS_NAME, REFRESH_INTERVAL_MS, get_hide_active_window_overlay, get_preview_tile_width, get_switch_window_enabled, get_switch_window_hotkey
+from bitcraft_preview.config import (
+    PROCESS_NAME,
+    REFRESH_INTERVAL_MS,
+    get_current_mode,
+    get_hide_active_window_overlay,
+    get_overlay_enabled,
+    get_preview_tile_width,
+    get_save_overlay_position_per_account,
+    get_show_overlay_only_when_focused,
+    get_switch_window_enabled,
+    get_switch_window_hotkey,
+)
+from bitcraft_preview.native.state_manager import NativeModeStateManager
 from bitcraft_preview.win32.title_parse import display_label
 from bitcraft_preview.win32.activation import activate_window
 from bitcraft_preview.win32.hotkey_monitor import GlobalHotkeyMonitor
@@ -18,6 +30,7 @@ HOTKEY_POLL_INTERVAL_MS = 25
 class OverlayManager:
     def __init__(self):
         self.overlays = {}  # target_hwnd -> LivePreviewTile overlay
+        self._overlay_windows = {}  # target_hwnd -> overlay widget hwnd
         self._live_refresh_queued = False
         self.hotkey_monitor = GlobalHotkeyMonitor()
         self._current_hotkey_spec = ""
@@ -76,6 +89,110 @@ class OverlayManager:
 
         return active_name == PROCESS_NAME.lower()
 
+    def _close_all_overlays(self):
+        for hwnd in list(self.overlays.keys()):
+            overlay = self.overlays.pop(hwnd)
+            self._overlay_windows.pop(hwnd, None)
+            overlay.close()
+            overlay.deleteLater()
+
+    def _is_overlay_interaction_active(self, active_hwnd=None):
+        normalized_active = self._normalize_hwnd(active_hwnd if active_hwnd is not None else self.get_active_window())
+        for target_hwnd, overlay in list(self.overlays.items()):
+            if getattr(overlay, "dragging", False):
+                return True
+            overlay_hwnd = self._overlay_windows.get(target_hwnd)
+            if overlay_hwnd is None:
+                try:
+                    overlay_hwnd = int(overlay.winId())
+                    self._overlay_windows[target_hwnd] = overlay_hwnd
+                except (TypeError, ValueError, RuntimeError):
+                    overlay_hwnd = None
+            if overlay_hwnd is not None and normalized_active == overlay_hwnd:
+                return True
+        return False
+
+    def _should_show_overlays(self, active_hwnd=None):
+        if not get_show_overlay_only_when_focused():
+            return True
+        if self._is_target_process_foreground():
+            return True
+        return self._is_overlay_interaction_active(active_hwnd)
+
+    def _build_native_instance_label_map(self):
+        label_map = {}
+        if get_current_mode() != "native":
+            return label_map
+        for instance in NativeModeStateManager().list_instances():
+            instance_key = instance.instance_id.strip().lower()
+            if instance_key:
+                label_map[instance_key] = instance
+            nickname_key = (instance.overlay_nickname or "").strip().lower()
+            if nickname_key:
+                label_map[nickname_key] = instance
+        return label_map
+
+    def _resolve_saved_tile_position(self, label_map, label_text):
+        if not get_save_overlay_position_per_account():
+            return None
+        if get_current_mode() != "native":
+            return None
+        instance = label_map.get((label_text or "").strip().lower())
+        if instance is None:
+            return None
+        x = int(getattr(instance, "tile_position_x", 0) or 0)
+        y = int(getattr(instance, "tile_position_y", 0) or 0)
+        if x == 0 and y == 0:
+            return None
+        return x, y
+
+    def _persist_tile_position(self, label_text, x, y):
+        if not get_save_overlay_position_per_account():
+            return
+        if get_current_mode() != "native":
+            return
+
+        normalized_label = (label_text or "").strip().lower()
+        if not normalized_label:
+            return
+
+        state = NativeModeStateManager()
+        instance = None
+        for row in state.list_instances():
+            if row.instance_id.strip().lower() == normalized_label:
+                instance = row
+                break
+            nickname = (row.overlay_nickname or "").strip().lower()
+            if nickname and nickname == normalized_label:
+                instance = row
+                break
+
+        if instance is None:
+            return
+
+        state.upsert_instance(
+            instance_id=instance.instance_id,
+            local_username=instance.local_username,
+            plain_password=None,
+            steam_account_name=instance.steam_account_name,
+            entity_id=instance.entity_id,
+            overlay_nickname=instance.overlay_nickname,
+            local_user_sid=instance.local_user_sid,
+            instance_root=instance.instance_root,
+            steam_exe_path=instance.steam_exe_path,
+            steamapps_link_path=instance.steamapps_link_path,
+            steamapps_link_target=instance.steamapps_link_target,
+            tile_position_x=int(x),
+            tile_position_y=int(y),
+            status=instance.status,
+        )
+
+    def _on_overlay_tile_position_changed(self, target_hwnd, x, y):
+        overlay = self.overlays.get(target_hwnd)
+        if overlay is None:
+            return
+        self._persist_tile_position(overlay.label_text, x, y)
+
     def _switch_to_next_window(self, windows):
         if not windows:
             return
@@ -125,11 +242,21 @@ class OverlayManager:
         self._live_refresh_queued = False
         self._refresh_hotkey_binding()
 
+        if not get_overlay_enabled():
+            self._close_all_overlays()
+            return
+
         active_hwnd = self.get_active_window()
+        show_overlays = self._should_show_overlays(active_hwnd)
         hide_active = get_hide_active_window_overlay()
 
         for hwnd, overlay in list(self.overlays.items()):
             overlay.sync_size()
+
+            if not show_overlays:
+                if overlay.isVisible():
+                    overlay.hide()
+                continue
 
             if hide_active and hwnd == active_hwnd:
                 if overlay.isVisible():
@@ -140,15 +267,23 @@ class OverlayManager:
 
     def refresh_windows(self):
         self._refresh_hotkey_binding()
+
+        if not get_overlay_enabled():
+            self._close_all_overlays()
+            return
+
         windows = enumerate_windows()
+        native_instances = self._build_native_instance_label_map()
 
         current_hwnds = {w.hwnd: w for w in windows}
         active_hwnd = self.get_active_window()
+        show_overlays = self._should_show_overlays(active_hwnd)
 
         # Remove closed windows
         for hwnd in list(self.overlays.keys()):
             if hwnd not in current_hwnds:
                 overlay = self.overlays.pop(hwnd)
+                self._overlay_windows.pop(hwnd, None)
                 overlay.close()
                 overlay.deleteLater()
                 logger.info(f"Removed overlay for window {hwnd}")
@@ -159,10 +294,22 @@ class OverlayManager:
             if window.hwnd not in self.overlays:
                 overlay = LivePreviewTile(window.hwnd, label_text)
                 self.overlays[window.hwnd] = overlay
+                overlay.position_changed.connect(
+                    lambda x, y, target_hwnd=window.hwnd: self._on_overlay_tile_position_changed(target_hwnd, x, y)
+                )
+
+                saved_position = self._resolve_saved_tile_position(native_instances, label_text)
+                if saved_position is not None:
+                    overlay.move(saved_position[0], saved_position[1])
+                else:
+                    # Default position (top-left offset)
+                    offset = 50 + (len(self.overlays) - 1) * get_preview_tile_width()
+                    overlay.move(offset, 50)
                 
-                # Default position (top-left offset)
-                offset = 50 + (len(self.overlays) - 1) * get_preview_tile_width()
-                overlay.move(offset, 50)
+                try:
+                    self._overlay_windows[window.hwnd] = int(overlay.winId())
+                except (TypeError, ValueError, RuntimeError):
+                    self._overlay_windows.pop(window.hwnd, None)
                 
                 logger.info(f"Added overlay for window {window.hwnd} [{label_text}]")
                 
@@ -174,6 +321,11 @@ class OverlayManager:
                     overlay.label_text = label_text
                     overlay.label.setText(label_text)
                 overlay.sync_size()
+
+            if not show_overlays:
+                if overlay.isVisible():
+                    overlay.hide()
+                continue
 
             # Hide overlay if this client is active and config enables it
             if get_hide_active_window_overlay() and window.hwnd == active_hwnd:

--- a/bitcraft_preview/ui/shell/accounts.py
+++ b/bitcraft_preview/ui/shell/accounts.py
@@ -74,7 +74,7 @@ def resolve_bulk_launch_targets(all_instance_ids: list[str], selected_ids: set[s
     return [instance_id for instance_id in all_instance_ids if instance_id in selected_ids]
 
 
-def build_instance_update_payload(instance: NativeInstance, nickname: str, entity_id: str) -> dict[str, str | None]:
+def build_instance_update_payload(instance: NativeInstance, nickname: str, entity_id: str) -> dict[str, str | int | None]:
     return {
         "instance_id": instance.instance_id,
         "local_username": instance.local_username,
@@ -87,6 +87,8 @@ def build_instance_update_payload(instance: NativeInstance, nickname: str, entit
         "steam_exe_path": instance.steam_exe_path,
         "steamapps_link_path": instance.steamapps_link_path,
         "steamapps_link_target": instance.steamapps_link_target,
+        "tile_position_x": instance.tile_position_x,
+        "tile_position_y": instance.tile_position_y,
         "status": instance.status,
     }
 

--- a/bitcraft_preview/ui/shell/panels.py
+++ b/bitcraft_preview/ui/shell/panels.py
@@ -74,35 +74,53 @@ class SettingsPanel(QWidget):
         )
         overlay_layout.addWidget(self.hide_active_overlay, 1, 0, 1, 3)
 
+        self.overlay_enabled = QCheckBox("Enable overlay preview")
+        self.overlay_enabled.stateChanged.connect(
+            lambda: self._set_user_bool("overlay_enabled", self.overlay_enabled.isChecked())
+        )
+        overlay_layout.addWidget(self.overlay_enabled, 2, 0, 1, 3)
+
+        self.focus_only_overlay = QCheckBox("Show overlay only when BitCraft is focused")
+        self.focus_only_overlay.stateChanged.connect(
+            lambda: self._set_user_bool("show_overlay_only_when_focused", self.focus_only_overlay.isChecked())
+        )
+        overlay_layout.addWidget(self.focus_only_overlay, 3, 0, 1, 3)
+
+        self.save_position_overlay = QCheckBox("Save overlay position per account")
+        self.save_position_overlay.stateChanged.connect(
+            lambda: self._set_user_bool("save_overlay_position_per_account", self.save_position_overlay.isChecked())
+        )
+        overlay_layout.addWidget(self.save_position_overlay, 4, 0, 1, 3)
+
         self.hover_zoom_enabled = QCheckBox("Enable hover zoom")
         self.hover_zoom_enabled.stateChanged.connect(
             lambda: self._set_user_bool("hover_zoom_enabled", self.hover_zoom_enabled.isChecked())
         )
-        overlay_layout.addWidget(self.hover_zoom_enabled, 2, 0, 1, 3)
+        overlay_layout.addWidget(self.hover_zoom_enabled, 5, 0, 1, 3)
 
         self.hover_zoom_name = QLabel("Hover zoom percent")
         self.hover_zoom_value = QLabel("200%")
         self.hover_zoom_percent = DirectInputSlider("Hover zoom percent", " %", self)
         self.hover_zoom_percent.setRange(100, 500)
         self.hover_zoom_percent.valueChanged.connect(self._on_zoom_changed)
-        self._add_inline_slider_row(overlay_layout, 3, self.hover_zoom_name, self.hover_zoom_percent, self.hover_zoom_value)
+        self._add_inline_slider_row(overlay_layout, 6, self.hover_zoom_name, self.hover_zoom_percent, self.hover_zoom_value)
 
         self.preview_tile_width_name = QLabel("Tile width")
         self.preview_tile_width_value = QLabel("300")
         self.preview_tile_width = DirectInputSlider("Tile width", " px", self)
         self.preview_tile_width.setRange(100, 500)
         self.preview_tile_width.valueChanged.connect(self._on_tile_size_changed)
-        self._add_inline_slider_row(overlay_layout, 4, self.preview_tile_width_name, self.preview_tile_width, self.preview_tile_width_value)
+        self._add_inline_slider_row(overlay_layout, 7, self.preview_tile_width_name, self.preview_tile_width, self.preview_tile_width_value)
 
         self.preview_tile_height_name = QLabel("Tile height")
         self.preview_tile_height_value = QLabel("200")
         self.preview_tile_height = DirectInputSlider("Tile height", " px", self)
         self.preview_tile_height.setRange(60, 500)
         self.preview_tile_height.valueChanged.connect(self._on_tile_size_changed)
-        self._add_inline_slider_row(overlay_layout, 5, self.preview_tile_height_name, self.preview_tile_height, self.preview_tile_height_value)
+        self._add_inline_slider_row(overlay_layout, 8, self.preview_tile_height_name, self.preview_tile_height, self.preview_tile_height_value)
 
         self.tile_preview = TilePreviewWidget(self)
-        overlay_layout.addWidget(self.tile_preview, 6, 0, 1, 3)
+        overlay_layout.addWidget(self.tile_preview, 9, 0, 1, 3)
 
         hotkey_content = QWidget(self)
         hotkey_layout = QGridLayout(hotkey_content)
@@ -167,6 +185,9 @@ class SettingsPanel(QWidget):
         self.hover_zoom_value.setText(f"{hover_zoom}%")
 
         self.hide_active_overlay.setChecked(bool(user.get("hide_active_window_overlay", False)))
+        self.overlay_enabled.setChecked(bool(user.get("overlay_enabled", True)))
+        self.focus_only_overlay.setChecked(bool(user.get("show_overlay_only_when_focused", False)))
+        self.save_position_overlay.setChecked(bool(user.get("save_overlay_position_per_account", True)))
         self.switch_window_enabled.setChecked(bool(user.get("switch_window_enabled", True)))
 
         hotkey = str(user.get("switch_window_hotkey", "MOUSE5") or "MOUSE5")

--- a/bitcraft_preview/ui/tile.py
+++ b/bitcraft_preview/ui/tile.py
@@ -1,20 +1,26 @@
 from PySide6.QtWidgets import QWidget, QLabel, QVBoxLayout, QGraphicsDropShadowEffect
-from PySide6.QtCore import Qt, QPoint, QRect
+from PySide6.QtCore import Qt, QPoint, QRect, Signal
 from PySide6.QtGui import QPainterPath, QRegion, QPainter, QColor
 import ctypes
 from bitcraft_preview.win32.dwm_thumbnail import register_thumbnail, update_thumbnail, unregister_thumbnail
 from bitcraft_preview.win32.activation import activate_window
 from bitcraft_preview.config import INLINE_LABEL, get_preview_opacity, get_hover_zoom_enabled, get_hover_zoom_percent, get_preview_tile_width, get_preview_tile_height
 
-LABEL_OPACITY_BOOST = 0.20
+user32 = ctypes.windll.user32
+SWP_NOSIZE = 0x0001
+SWP_NOMOVE = 0x0002
+SWP_NOACTIVATE = 0x0010
 
 class LivePreviewTile(QWidget):
+    position_changed = Signal(int, int)
+
     def __init__(self, target_hwnd: int, label_text: str, parent=None):
         super().__init__(parent)
         self.target_hwnd = target_hwnd
         self.label_text = label_text
         self.thumbnail_handle = None
         self.dragging = False
+        self._drag_moved = False
         self.drag_start_position = None
         self.window_start_position = None
         self.is_hovered = False
@@ -78,12 +84,7 @@ class LivePreviewTile(QWidget):
         return max(0.0, min(1.0, float(value)))
 
     def _compute_label_opacity(self) -> float:
-        preview_opacity = self._clamp_opacity(get_preview_opacity())
-        if preview_opacity <= 0.0:
-            return 0.0
-        if preview_opacity >= 1.0:
-            return 1.0
-        return self._clamp_opacity(preview_opacity + LABEL_OPACITY_BOOST)
+        return 1.0
 
     def _refresh_label_visuals(self):
         label_opacity = self._compute_label_opacity()
@@ -124,6 +125,7 @@ class LivePreviewTile(QWidget):
     def mousePressEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:
             self.dragging = True
+            self._drag_moved = False
             self.drag_start_position = event.globalPosition().toPoint()
             self.window_start_position = self.frameGeometry().topLeft()
             
@@ -136,6 +138,8 @@ class LivePreviewTile(QWidget):
     def mouseMoveEvent(self, event):
         if self.dragging:
             delta = event.globalPosition().toPoint() - self.drag_start_position
+            if delta.manhattanLength() > 0:
+                self._drag_moved = True
             new_pos = self.window_start_position + delta
             self.move(new_pos)
             
@@ -161,8 +165,12 @@ class LivePreviewTile(QWidget):
             self.dragging = False
             # Check if it was a fast click vs a drag
             delta = event.globalPosition().toPoint() - self.drag_start_position
+            if self._drag_moved:
+                pos = self.frameGeometry().topLeft()
+                self.position_changed.emit(int(pos.x()), int(pos.y()))
             if delta.manhattanLength() < 5:
                 activate_window(self.target_hwnd)
+            self._drag_moved = False
             event.accept()
 
 
@@ -173,7 +181,7 @@ class LivePreviewTile(QWidget):
         # Always bring hovered window completely to top so it's over other preview tiles!
         self.raise_()
         if INLINE_LABEL and hasattr(self, 'label') and self.label:
-            self.label.raise_()
+            self._sync_inline_label_window(ensure_visible=True)
         
         if self.dragging:
             return
@@ -259,12 +267,39 @@ class LivePreviewTile(QWidget):
         self.update_thumbnail_rect()
         self._refresh_label_visuals()
 
+    def _stack_inline_label_above_tile(self):
+        if not INLINE_LABEL or not self.label.isVisible():
+            return
+
+        try:
+            label_hwnd = int(self.label.winId())
+            tile_hwnd = int(self.winId())
+        except (TypeError, ValueError, RuntimeError):
+            self.label.raise_()
+            return
+
+        flags = SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE
+        if not user32.SetWindowPos(tile_hwnd, label_hwnd, 0, 0, 0, 0, flags):
+            self.label.raise_()
+
+    def _sync_inline_label_window(self, ensure_visible: bool = False):
+        if not INLINE_LABEL or not hasattr(self, 'label') or self.label is None:
+            return
+        if not self.isVisible():
+            return
+
+        if ensure_visible and not self.label.isVisible():
+            self.label.show()
+
+        if not self.label.isVisible():
+            return
+
+        bottom_left = self.mapToGlobal(QPoint(10, self.height() - self.label.height() - 10))
+        self.label.move(bottom_left)
+        self._stack_inline_label_above_tile()
+
     def update_inline_label_position(self):
-        if INLINE_LABEL and self.label.isVisible():
-            # mapToGlobal converts local logical coords to global logical screen coords,
-            # which is what move() on a parentless top-level window expects.
-            bottom_left = self.mapToGlobal(QPoint(10, self.height() - self.label.height() - 10))
-            self.label.move(bottom_left)
+        self._sync_inline_label_window()
 
     def sync_size(self):
         """Called each refresh tick to apply live config size changes."""
@@ -284,8 +319,7 @@ class LivePreviewTile(QWidget):
     def showEvent(self, event):
         super().showEvent(event)
         if INLINE_LABEL:
-            self.label.show()
-            self.update_inline_label_position()
+            self._sync_inline_label_window(ensure_visible=True)
             
         if not self.thumbnail_handle:
             win_id = int(self.winId())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bitcraft_preview"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Multibox tool for Bitcraft"
 dependencies = [
     "PySide6",

--- a/tests/test_accounts_logic.py
+++ b/tests/test_accounts_logic.py
@@ -51,6 +51,8 @@ class AccountsLogicTests(unittest.TestCase):
             steam_exe_path=r"C:\BitcraftPreview\SteamInstances\Steam2\steam.exe",
             steamapps_link_path=r"C:\BitcraftPreview\SteamInstances\Steam2\steamapps",
             steamapps_link_target=r"D:\SteamLibrary\steamapps",
+            tile_position_x=900,
+            tile_position_y=450,
             status="ready",
         )
 
@@ -63,6 +65,8 @@ class AccountsLogicTests(unittest.TestCase):
         self.assertEqual(payload["entity_id"], "new-entity")
         self.assertEqual(payload["steam_exe_path"], instance.steam_exe_path)
         self.assertEqual(payload["steamapps_link_target"], instance.steamapps_link_target)
+        self.assertEqual(payload["tile_position_x"], 900)
+        self.assertEqual(payload["tile_position_y"], 450)
         self.assertEqual(payload["status"], "ready")
 
 

--- a/tests/test_config_updates.py
+++ b/tests/test_config_updates.py
@@ -43,6 +43,9 @@ class ConfigUpdateTests(unittest.TestCase):
                 self.assertIn("hover_zoom_enabled", loaded["UserSettings"])
                 self.assertIn("switch_window_hotkey", loaded["UserSettings"])
                 self.assertIn("preview_tile_width", loaded["UserSettings"])
+                self.assertIn("overlay_enabled", loaded["UserSettings"])
+                self.assertIn("show_overlay_only_when_focused", loaded["UserSettings"])
+                self.assertIn("save_overlay_position_per_account", loaded["UserSettings"])
                 
                 # Verify old values preserved
                 self.assertEqual(loaded["UserSettings"]["inline_label"], True)
@@ -54,6 +57,9 @@ class ConfigUpdateTests(unittest.TestCase):
                 
                 self.assertIn("hover_zoom_enabled", saved_config["UserSettings"])
                 self.assertIn("switch_window_hotkey", saved_config["UserSettings"])
+                self.assertIn("overlay_enabled", saved_config["UserSettings"])
+                self.assertIn("show_overlay_only_when_focused", saved_config["UserSettings"])
+                self.assertIn("save_overlay_position_per_account", saved_config["UserSettings"])
 
     def test_new_native_mode_option_gets_added(self):
         """When DEFAULT_CONFIG gets a new native_mode option, it should be added."""
@@ -154,7 +160,7 @@ class ConfigUpdateTests(unittest.TestCase):
                     saved_config = json.load(f)
 
                 self.assertIn("gui", saved_config)
-                self.assertEqual(saved_config["gui"]["open_on_startup"], False)
+                self.assertEqual(saved_config["gui"]["open_on_startup"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_state_manager.py
+++ b/tests/test_native_state_manager.py
@@ -130,6 +130,46 @@ class NativeStateManagerTests(unittest.TestCase):
         self.assertEqual(updated.entity_id, "entity-abc")
         self.assertEqual(updated.overlay_nickname, "Alt")
 
+    def test_upsert_persists_tile_position(self) -> None:
+        manager = NativeModeStateManager()
+        with patch("bitcraft_preview.native.state_manager.protect_text", return_value="ENC"):
+            manager.upsert_instance(
+                instance_id="steam6",
+                local_username="bitcraft6",
+                plain_password="pw",
+                tile_position_x=345,
+                tile_position_y=678,
+            )
+
+        saved = manager.get_instance("steam6")
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved.tile_position_x, 345)
+        self.assertEqual(saved.tile_position_y, 678)
+
+    def test_upsert_preserves_tile_position_when_none(self) -> None:
+        manager = NativeModeStateManager()
+        with patch("bitcraft_preview.native.state_manager.protect_text", return_value="ENC"):
+            manager.upsert_instance(
+                instance_id="steam7",
+                local_username="bitcraft7",
+                plain_password="pw",
+                tile_position_x=111,
+                tile_position_y=222,
+            )
+
+        manager.upsert_instance(
+            instance_id="steam7",
+            local_username="bitcraft7",
+            tile_position_x=None,
+            tile_position_y=None,
+            status=None,
+        )
+
+        saved = manager.get_instance("steam7")
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved.tile_position_x, 111)
+        self.assertEqual(saved.tile_position_y, 222)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_overlay_manager_logic.py
+++ b/tests/test_overlay_manager_logic.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch
+
+from bitcraft_preview.ui.overlay_manager import OverlayManager
+
+
+class _FakeOverlay:
+    def __init__(self, visible=True, dragging=False, hwnd=9001, label_text="steam1"):
+        self._visible = visible
+        self.dragging = dragging
+        self._hwnd = hwnd
+        self.label_text = label_text
+        self.hidden_calls = 0
+        self.shown_calls = 0
+        self.update_calls = 0
+        self.sync_calls = 0
+
+    def sync_size(self):
+        self.sync_calls += 1
+
+    def isVisible(self):
+        return self._visible
+
+    def hide(self):
+        self._visible = False
+        self.hidden_calls += 1
+
+    def show(self):
+        self._visible = True
+        self.shown_calls += 1
+
+    def update_thumbnail_rect(self):
+        self.update_calls += 1
+
+    def winId(self):
+        return self._hwnd
+
+
+class OverlayManagerLogicTests(unittest.TestCase):
+    def _manager(self):
+        manager = OverlayManager.__new__(OverlayManager)
+        manager.overlays = {}
+        manager._overlay_windows = {}
+        manager._live_refresh_queued = False
+        manager._refresh_hotkey_binding = lambda: None
+        manager.get_active_window = lambda: 0
+        manager._is_target_process_foreground = lambda: False
+        return manager
+
+    def test_should_show_overlays_when_focus_only_disabled(self):
+        manager = self._manager()
+        with patch("bitcraft_preview.ui.overlay_manager.get_show_overlay_only_when_focused", return_value=False):
+            self.assertTrue(manager._should_show_overlays())
+
+    def test_should_show_overlays_while_dragging_even_when_unfocused(self):
+        manager = self._manager()
+        manager.overlays = {123: _FakeOverlay(dragging=True)}
+        with patch("bitcraft_preview.ui.overlay_manager.get_show_overlay_only_when_focused", return_value=True):
+            self.assertTrue(manager._should_show_overlays(active_hwnd=0))
+
+    def test_apply_live_settings_hides_when_focus_only_unfocused(self):
+        manager = self._manager()
+        overlay = _FakeOverlay(visible=True, dragging=False)
+        manager.overlays = {111: overlay}
+
+        with (
+            patch("bitcraft_preview.ui.overlay_manager.get_overlay_enabled", return_value=True),
+            patch("bitcraft_preview.ui.overlay_manager.get_show_overlay_only_when_focused", return_value=True),
+            patch("bitcraft_preview.ui.overlay_manager.get_hide_active_window_overlay", return_value=False),
+        ):
+            manager._apply_live_settings()
+
+        self.assertEqual(overlay.sync_calls, 1)
+        self.assertEqual(overlay.hidden_calls, 1)
+        self.assertFalse(overlay.isVisible())
+
+    def test_apply_live_settings_shows_overlay_when_refocused(self):
+        manager = self._manager()
+        overlay = _FakeOverlay(visible=False, dragging=False)
+        manager.overlays = {111: overlay}
+        manager._is_target_process_foreground = lambda: True
+
+        with (
+            patch("bitcraft_preview.ui.overlay_manager.get_overlay_enabled", return_value=True),
+            patch("bitcraft_preview.ui.overlay_manager.get_show_overlay_only_when_focused", return_value=True),
+            patch("bitcraft_preview.ui.overlay_manager.get_hide_active_window_overlay", return_value=False),
+        ):
+            manager._apply_live_settings()
+
+        self.assertEqual(overlay.sync_calls, 1)
+        self.assertEqual(overlay.shown_calls, 1)
+        self.assertEqual(overlay.update_calls, 1)
+        self.assertTrue(overlay.isVisible())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tile_inline_label.py
+++ b/tests/test_tile_inline_label.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+
+from PySide6.QtCore import QPoint
+
+from bitcraft_preview.ui.tile import LivePreviewTile
+
+
+class _FakeLabel:
+    def __init__(self, visible=False, hwnd=222):
+        self._visible = visible
+        self._hwnd = hwnd
+        self.show_calls = 0
+        self.raise_calls = 0
+        self.move_calls = []
+
+    def isVisible(self):
+        return self._visible
+
+    def show(self):
+        self._visible = True
+        self.show_calls += 1
+
+    def raise_(self):
+        self.raise_calls += 1
+
+    def move(self, point):
+        self.move_calls.append(point)
+
+    def height(self):
+        return 24
+
+    def winId(self):
+        return self._hwnd
+
+
+class LivePreviewTileInlineLabelTests(unittest.TestCase):
+    def _tile(self, *, visible=True, label_visible=False):
+        tile = LivePreviewTile.__new__(LivePreviewTile)
+        tile.label = _FakeLabel(visible=label_visible)
+        tile.isVisible = lambda: visible
+        tile.height = lambda: 200
+        tile.mapToGlobal = lambda point: QPoint(50, 60)
+        tile.winId = lambda: 111
+        return tile
+
+    def test_sync_inline_label_shows_moves_and_stacks_label(self):
+        tile = self._tile(visible=True, label_visible=False)
+
+        with (
+            patch("bitcraft_preview.ui.tile.INLINE_LABEL", True),
+            patch("bitcraft_preview.ui.tile.user32.SetWindowPos", return_value=1) as set_window_pos,
+        ):
+            tile._sync_inline_label_window(ensure_visible=True)
+
+        self.assertEqual(tile.label.show_calls, 1)
+        self.assertEqual(tile.label.move_calls, [QPoint(50, 60)])
+        set_window_pos.assert_called_once_with(
+            111,
+            222,
+            0,
+            0,
+            0,
+            0,
+            0x0001 | 0x0002 | 0x0010,
+        )
+
+    def test_sync_inline_label_falls_back_to_raise_when_native_stack_fails(self):
+        tile = self._tile(visible=True, label_visible=True)
+
+        with (
+            patch("bitcraft_preview.ui.tile.INLINE_LABEL", True),
+            patch("bitcraft_preview.ui.tile.user32.SetWindowPos", return_value=0),
+        ):
+            tile._sync_inline_label_window()
+
+        self.assertEqual(tile.label.raise_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces several new overlay management features and improvements to the BitCraft Preview application. The main changes include new user-configurable overlay options, the ability to save and restore overlay positions per account, and enhancements to overlay visibility logic. These updates improve user control over overlay behavior and persistence across sessions.

**Overlay feature enhancements:**

* Added new user settings for overlays: enable/disable overlay preview, show overlay only when BitCraft is focused, and save overlay position per account. These are now available in the configuration and UI settings panel. [[1]](diffhunk://#diff-db0132dfed799a98f4c18bfaa5399d2d1dc6d6bba3256ec526b3c578f464df76R18-R24) [[2]](diffhunk://#diff-cc083176968a8403154aaf9cbf171908153a43fe7657cef870022de450892c10R77-R123) [[3]](diffhunk://#diff-cc083176968a8403154aaf9cbf171908153a43fe7657cef870022de450892c10R188-R190)
* Implemented getter functions for the new overlay settings in `config.py` for real-time access throughout the application.

**Overlay position persistence:**

* Extended the `NativeInstance` model and related state management to store `tile_position_x` and `tile_position_y` for each account, enabling overlays to remember their last position per account. [[1]](diffhunk://#diff-8cb3057c0967c1ffb8b1941fa1b5a39716cf5a94b81d565ee31952ebd6045392R42-R43) [[2]](diffhunk://#diff-8cb3057c0967c1ffb8b1941fa1b5a39716cf5a94b81d565ee31952ebd6045392R137-R138) [[3]](diffhunk://#diff-8cb3057c0967c1ffb8b1941fa1b5a39716cf5a94b81d565ee31952ebd6045392R167-R168) [[4]](diffhunk://#diff-5f7b1f324f3104c208bf051024699a791a4cc62a921ddca957c4d3b47468d323L77-R77) [[5]](diffhunk://#diff-5f7b1f324f3104c208bf051024699a791a4cc62a921ddca957c4d3b47468d323R90-R91)
* Updated `OverlayManager` to resolve and persist overlay positions based on account information, and to restore positions when overlays are recreated. [[1]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R92-R195) [[2]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R297-R313)

**Overlay visibility and interaction logic:**

* Improved overlay visibility logic: overlays can now be hidden when BitCraft is not focused or when the overlay is disabled, and overlays are only shown when appropriate based on new settings. [[1]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R245-R260) [[2]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R270-R286) [[3]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R325-R329)
* Added logic to close all overlays when overlay preview is disabled and to track overlay window handles for better management. [[1]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R33) [[2]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R245-R260) [[3]](diffhunk://#diff-121dd82e99609b6f1b66c4b4a60ac83cb2ceaed989e2a39f867088e7fc13c264R270-R286)


**UI improvements:**

* Updated the settings panel to include checkboxes for the new overlay options and adjusted layout for clarity. [[1]](diffhunk://#diff-cc083176968a8403154aaf9cbf171908153a43fe7657cef870022de450892c10R77-R123) [[2]](diffhunk://#diff-cc083176968a8403154aaf9cbf171908153a43fe7657cef870022de450892c10R188-R190)

**Codebase enhancements:**

* Added a `position_changed` Qt signal to `LivePreviewTile` to notify when an overlay is moved, allowing position persistence.
* Minor refactoring and improvements in overlay tile opacity and drag handling. [[1]](diffhunk://#diff-77db92e354abc6c995e62d37af2810710ec0c81eacdd071ac9b2158dad58592aL81-L86) [[2]](diffhunk://#diff-77db92e354abc6c995e62d37af2810710ec0c81eacdd071ac9b2158dad58592aR128)Introduce overlay-related settings and per-account saved tile positions. Config: add overlay_enabled, show_overlay_only_when_focused, save_overlay_position_per_account and real-time getters. Native state: persist tile_position_x/y and preserve existing values when upserting. UI: add checkboxes in SettingsPanel to control overlay enable, focus-only display, and per-account position saving; include tile position in instance update payload. OverlayManager: respect overlay_enabled and focus-only behavior, close/hide overlays appropriately, map native instances for nickname/ID lookup, restore saved positions on creation, persist position changes from tiles, and track overlay window handles. LivePreviewTile: emit position_changed on drag end, improve drag detection, and use SetWindowPos to stack inline label above tile (with fallback). Tests: add coverage for overlay/show-only logic and inline-label stacking, and update native/account tests for tile position persistence and config defaults. closes #6  