### PR TITLE
Native account repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ These labels can also be changed directly from the tray menu.
 - No windows found: verify that the BitCraft process is still named `BitCraft.exe`.
 - Blank or black thumbnails: DWM thumbnails can fail in some fullscreen or overlay-heavy configurations. Borderless or windowed mode is usually more reliable.
 - Native restart still leaves stale profile folders: check `%LOCALAPPDATA%\BitCraftPreview\bitcraft_preview.log` for profile-unload wait warnings.
+- Native launch fails with `[WinError 1327] Account restrictions are preventing this user from signing in`: run `Native Repair...` from the tray tools menu as Administrator. Repair resets app-managed `bitcraft1`, `bitcraft2`, ... passwords, marks them as non-expiring, and updates encrypted config. This usually means the local Windows password policy expired the managed account passwords.
 - Tray shows `Restart` instead of `Launch`: BitCraft Preview detected `steam.exe` or `BitCraft.exe` already running for that native account.
 - Migrating from older builds: if you previously had a `config.json` next to the executable, move it to `%LOCALAPPDATA%\BitCraftPreview\config.json`.
 

--- a/bitcraft_preview/__main__.py
+++ b/bitcraft_preview/__main__.py
@@ -63,6 +63,21 @@ def _run_native_cli(args) -> None:
             )
             return
 
+        if args.native_repair:
+            if not args.native_ack_user_changes:
+                print(setup_disclaimer_text())
+                print("\nRepair aborted. Re-run with --native-ack-user-changes to continue.")
+                raise SystemExit(2)
+
+            service = NativeSetupService()
+            summary = service.repair()
+            print(
+                "Native repair complete:",
+                f"users_repaired={summary.users_repaired}",
+                f"users_failed={summary.users_failed}",
+            )
+            return
+
         controller = NativeProcessController()
         if args.native_launch:
             result = controller.launch_instance(args.native_launch)
@@ -120,11 +135,12 @@ def main():
     )
     parser.add_argument("--native-setup", dest="native_setup", type=int, help="Reconcile and provision native setup for N instances")
     parser.add_argument("--native-cleanup", dest="native_cleanup", action="store_true", help="Cleanup app-managed native users/folders")
+    parser.add_argument("--native-repair", dest="native_repair", action="store_true", help="Repair app-managed native users and rotate stored passwords")
     parser.add_argument(
         "--native-ack-user-changes",
         dest="native_ack_user_changes",
         action="store_true",
-        help="Acknowledge Windows user account modifications for native setup/cleanup",
+        help="Acknowledge Windows user account modifications for native setup/repair/cleanup",
     )
     args = parser.parse_args()
 
@@ -135,6 +151,7 @@ def main():
         or args.native_relogin
         or args.native_setup is not None
         or args.native_cleanup
+        or args.native_repair
     )
     if native_request:
         _run_native_cli(args)
@@ -600,6 +617,43 @@ def main():
             logger.exception("Unexpected tray native cleanup error")
             QMessageBox.critical(None, "Native Cleanup Error", str(e))
 
+    def _run_native_repair_from_tray() -> None:
+        if not _require_native_admin("repair"):
+            return
+
+        if not _confirm_native_account_changes("Native repair"):
+            return
+
+        confirm = QMessageBox.warning(
+            None,
+            "Confirm Native Repair",
+            (
+                "This will reset passwords for app-managed local Windows users "
+                "(bitcraft1, bitcraft2, ...), mark them as non-expiring, and update encrypted config.\n\n"
+                "Continue?"
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            summary = NativeSetupService().repair()
+            message = (
+                "Native repair complete.\n"
+                f"users_repaired={summary.users_repaired}, users_failed={summary.users_failed}"
+            )
+            logger.info(message)
+            QMessageBox.information(None, "Native Repair Complete", message)
+            _refresh_overlay_and_tray_labels()
+        except NativeSetupError as e:
+            logger.error("Native repair failed from tray: %s", e)
+            QMessageBox.critical(None, "Native Repair Error", str(e))
+        except Exception as e:
+            logger.exception("Unexpected tray native repair error")
+            QMessageBox.critical(None, "Native Repair Error", str(e))
+
     _update_tray_action = QAction("", tray_menu)
     _update_tray_action.setVisible(False)
     _update_tray_action.triggered.connect(lambda: QDesktopServices.openUrl(QUrl(GITHUB_RELEASES_PAGE)))
@@ -622,6 +676,10 @@ def main():
     native_setup_action = QAction("Native Setup...", app)
     native_setup_action.triggered.connect(_run_native_setup_from_tray)
     tools_menu.addAction(native_setup_action)
+
+    native_repair_action = QAction("Native Repair...", app)
+    native_repair_action.triggered.connect(_run_native_repair_from_tray)
+    tools_menu.addAction(native_repair_action)
 
     native_cleanup_action = QAction("Native Cleanup...", app)
     native_cleanup_action.triggered.connect(_run_native_cleanup_from_tray)

--- a/bitcraft_preview/native/__init__.py
+++ b/bitcraft_preview/native/__init__.py
@@ -3,7 +3,7 @@
 from .local_user_manager import LocalUserManager, LocalUserError
 from .process_control import NativeProcessController, NativeProcessControlError
 from .process_launcher import ProcessLauncher, ProcessLaunchError
-from .setup_service import CleanupSummary, NativeSetupError, NativeSetupService, is_admin, setup_disclaimer_text
+from .setup_service import CleanupSummary, NativeSetupError, NativeSetupService, RepairSummary, is_admin, setup_disclaimer_text
 from .steam_locator import SteamInstallInfo, SteamLocatorError, find_bitcraft_install, get_primary_steam_path
 from .state_manager import NativeModeStateManager
 
@@ -17,6 +17,7 @@ __all__ = [
     "NativeSetupService",
     "NativeSetupError",
     "CleanupSummary",
+    "RepairSummary",
     "is_admin",
     "setup_disclaimer_text",
     "SteamInstallInfo",

--- a/bitcraft_preview/native/local_user_manager.py
+++ b/bitcraft_preview/native/local_user_manager.py
@@ -18,7 +18,7 @@ kernel32 = ctypes.windll.kernel32
 
 
 def _run_command(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, check=False, capture_output=True, text=True)
+    return subprocess.run(args, check=False, capture_output=True, text=True, errors="replace")
 
 
 def _generate_password(length: int = 14) -> str:
@@ -48,8 +48,7 @@ def _harden_user_with_powershell(username: str) -> subprocess.CompletedProcess[s
     escaped_user = username.replace("'", "''")
     command = (
         f"Set-LocalUser -Name '{escaped_user}' -AccountNeverExpires "
-        f"-PasswordNeverExpires $true -UserMayChangePassword $false; "
-        f"Add-LocalGroupMember -SID 'S-1-5-32-545' -Member '{escaped_user}' -ErrorAction SilentlyContinue"
+        f"-PasswordNeverExpires $true -UserMayChangePassword $false"
     )
     return _run_command(["powershell", "-NoProfile", "-NonInteractive", "-Command", command])
 

--- a/bitcraft_preview/native/local_user_manager.py
+++ b/bitcraft_preview/native/local_user_manager.py
@@ -169,7 +169,7 @@ class LocalUserManager:
             detail = stderr or stdout or f"exit code {result.returncode}"
             raise LocalUserError(f"Failed to set non-expiring password for {username}: {detail}")
 
-    def repair_user(self, username: str, password: str) -> None:
+    def reset_password(self, username: str, password: str) -> None:
         if not self.user_exists(username):
             raise LocalUserError(f"User does not exist: {username}")
 
@@ -180,6 +180,8 @@ class LocalUserManager:
             detail = stderr or stdout or f"exit code {result.returncode}"
             raise LocalUserError(f"Failed to reset password for {username}: {detail}")
 
+    def repair_user(self, username: str, password: str) -> None:
+        self.reset_password(username, password)
         self.harden_user(username)
 
     def delete_user(self, username: str) -> None:

--- a/bitcraft_preview/native/local_user_manager.py
+++ b/bitcraft_preview/native/local_user_manager.py
@@ -44,6 +44,16 @@ def _create_user_with_powershell(username: str, password: str) -> subprocess.Com
     return _run_command(["powershell", "-NoProfile", "-NonInteractive", "-Command", command])
 
 
+def _harden_user_with_powershell(username: str) -> subprocess.CompletedProcess[str]:
+    escaped_user = username.replace("'", "''")
+    command = (
+        f"Set-LocalUser -Name '{escaped_user}' -AccountNeverExpires "
+        f"-PasswordNeverExpires $true -UserMayChangePassword $false; "
+        f"Add-LocalGroupMember -SID 'S-1-5-32-545' -Member '{escaped_user}' -ErrorAction SilentlyContinue"
+    )
+    return _run_command(["powershell", "-NoProfile", "-NonInteractive", "-Command", command])
+
+
 def _lookup_account_sid(account_name: str) -> str:
     name = account_name
 
@@ -113,6 +123,7 @@ class LocalUserManager:
             # Some environments return "No valid response was provided." from net.exe.
             fallback = _create_user_with_powershell(username, final_password)
             if fallback.returncode == 0:
+                self.harden_user(username)
                 return final_password
 
             stderr = (result.stderr or "").strip()
@@ -130,8 +141,47 @@ class LocalUserManager:
         # Note: net.exe doesn't support SID directly, but Users should exist on all Windows installs.
         # If this fails on non-English Windows, the PowerShell fallback above will handle it.
         _run_command(["net", "localgroup", "Users", username, "/add"])
+        self.harden_user(username)
 
         return final_password
+
+    def harden_user(self, username: str) -> None:
+        if not self.user_exists(username):
+            raise LocalUserError(f"User does not exist: {username}")
+
+        commands = [
+            ["net", "user", username, "/active:yes"],
+            ["net", "user", username, "/expires:never"],
+            ["net", "user", username, "/times:all"],
+        ]
+        for args in commands:
+            result = _run_command(args)
+            if result.returncode != 0:
+                stderr = (result.stderr or "").strip()
+                stdout = (result.stdout or "").strip()
+                detail = stderr or stdout or f"exit code {result.returncode}"
+                raise LocalUserError(f"Failed to harden user {username}: {detail}")
+
+        _run_command(["net", "localgroup", "Users", username, "/add"])
+        result = _harden_user_with_powershell(username)
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            detail = stderr or stdout or f"exit code {result.returncode}"
+            raise LocalUserError(f"Failed to set non-expiring password for {username}: {detail}")
+
+    def repair_user(self, username: str, password: str) -> None:
+        if not self.user_exists(username):
+            raise LocalUserError(f"User does not exist: {username}")
+
+        result = _run_command(["net", "user", username, password])
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            stdout = (result.stdout or "").strip()
+            detail = stderr or stdout or f"exit code {result.returncode}"
+            raise LocalUserError(f"Failed to reset password for {username}: {detail}")
+
+        self.harden_user(username)
 
     def delete_user(self, username: str) -> None:
         if not self.user_exists(username):

--- a/bitcraft_preview/native/process_control.py
+++ b/bitcraft_preview/native/process_control.py
@@ -10,12 +10,14 @@ from typing import List
 
 import psutil
 
-from .process_launcher import ProcessLauncher
+from .process_launcher import ProcessLaunchError, ProcessLauncher
 from .state_manager import NativeInstance, NativeModeStateManager
 
 logger = logging.getLogger(__name__)
 
 APP_ID_BITCRAFT = 3454650
+
+ERROR_ACCOUNT_RESTRICTION = 1327
 
 
 def _wait_for_profile_unloaded(sid: str, timeout: float = 15.0) -> None:
@@ -231,6 +233,16 @@ class NativeProcessController:
         safe = re.sub(r"[^a-zA-Z0-9]", "", instance_id) or "steam"
         return f"steam{safe}"
 
+    @staticmethod
+    def _friendly_launch_error(instance: NativeInstance, error: ProcessLaunchError) -> NativeProcessControlError:
+        if error.winerror == ERROR_ACCOUNT_RESTRICTION or "WinError 1327" in str(error):
+            return NativeProcessControlError(
+                f"Windows rejected native account '{instance.local_username}' for {instance.instance_id}. "
+                "The password or account policy is likely expired/restricted. "
+                "Run Native Repair as Administrator, then launch again."
+            )
+        return NativeProcessControlError(str(error))
+
     def _launch(
         self,
         instance: NativeInstance,
@@ -264,22 +276,28 @@ class NativeProcessController:
         )
         if userchooser_mode:
             args = f"-master_ipc_name_override {override} -userchooser"
-            steam_pid = self._launcher.launch_foreground(
-                username=instance.local_username,
-                password=password,
-                exe_path=instance.steam_exe_path,
-                args=args,
-                working_directory=working_dir,
-            )
+            try:
+                steam_pid = self._launcher.launch_foreground(
+                    username=instance.local_username,
+                    password=password,
+                    exe_path=instance.steam_exe_path,
+                    args=args,
+                    working_directory=working_dir,
+                )
+            except ProcessLaunchError as e:
+                raise self._friendly_launch_error(instance, e) from e
         else:
             args = f"-master_ipc_name_override {override} -silent -applaunch {APP_ID_BITCRAFT}"
-            steam_pid = self._launcher.launch_silent(
-                username=instance.local_username,
-                password=password,
-                exe_path=instance.steam_exe_path,
-                args=args,
-                working_directory=working_dir,
-            )
+            try:
+                steam_pid = self._launcher.launch_silent(
+                    username=instance.local_username,
+                    password=password,
+                    exe_path=instance.steam_exe_path,
+                    args=args,
+                    working_directory=working_dir,
+                )
+            except ProcessLaunchError as e:
+                raise self._friendly_launch_error(instance, e) from e
 
         logger.debug("Steam launched: instance=%s steam_pid=%d", instance.instance_id, steam_pid)
         return LaunchResult(

--- a/bitcraft_preview/native/process_launcher.py
+++ b/bitcraft_preview/native/process_launcher.py
@@ -5,7 +5,9 @@ from ctypes import wintypes
 
 
 class ProcessLaunchError(RuntimeError):
-    pass
+    def __init__(self, message: str, winerror: int | None = None) -> None:
+        super().__init__(message)
+        self.winerror = winerror
 
 
 LOGON_WITH_PROFILE = 0x00000001
@@ -86,7 +88,8 @@ class ProcessLauncher:
             ctypes.byref(process_info),
         )
         if not ok:
-            raise ProcessLaunchError(str(ctypes.WinError()))
+            error = ctypes.WinError()
+            raise ProcessLaunchError(str(error), getattr(error, "winerror", None))
 
         try:
             return int(process_info.dwProcessId)

--- a/bitcraft_preview/native/setup_service.py
+++ b/bitcraft_preview/native/setup_service.py
@@ -244,7 +244,7 @@ class NativeSetupService:
         for instance in instances:
             password = LocalUserManager.generate_password()
             try:
-                self._users.repair_user(instance.local_username, password)
+                self._users.reset_password(instance.local_username, password)
                 sid = self._users.get_user_sid(instance.local_username)
                 self._state.upsert_instance(
                     instance_id=instance.instance_id,
@@ -253,6 +253,7 @@ class NativeSetupService:
                     local_user_sid=sid,
                     status="ready",
                 )
+                self._users.harden_user(instance.local_username)
                 summary.users_repaired += 1
             except Exception as e:
                 summary.users_failed += 1

--- a/bitcraft_preview/native/setup_service.py
+++ b/bitcraft_preview/native/setup_service.py
@@ -26,6 +26,12 @@ class CleanupSummary:
     folders_failed: int = 0
 
 
+@dataclass
+class RepairSummary:
+    users_repaired: int = 0
+    users_failed: int = 0
+
+
 def is_admin() -> bool:
     """Check if the current process has administrator privileges."""
     try:
@@ -180,6 +186,7 @@ class NativeSetupService:
                     f"No managed password available for existing user '{username}'. "
                     "Reset password manually and rerun setup."
                 )
+            self._users.harden_user(username)
 
             if os.path.isdir(instance_root):
                 summary.folders_reused += 1
@@ -219,6 +226,41 @@ class NativeSetupService:
         cfg["mode"] = "native"
         self._state.save_config(cfg)
         self._state.set_last_reconcile(summary)
+        return summary
+
+    def repair(self) -> RepairSummary:
+        if not is_admin():
+            raise NativeSetupError(
+                "Native Mode repair requires Administrator privileges. "
+                "Please run BitCraftPreview.exe as Administrator."
+            )
+
+        instances = [instance for instance in self._state.list_instances() if instance.managed_by_app and instance.local_username]
+        if not instances:
+            raise NativeSetupError("No managed native accounts configured.")
+
+        summary = RepairSummary()
+        failures: list[str] = []
+        for instance in instances:
+            password = LocalUserManager.generate_password()
+            try:
+                self._users.repair_user(instance.local_username, password)
+                sid = self._users.get_user_sid(instance.local_username)
+                self._state.upsert_instance(
+                    instance_id=instance.instance_id,
+                    local_username=instance.local_username,
+                    plain_password=password,
+                    local_user_sid=sid,
+                    status="ready",
+                )
+                summary.users_repaired += 1
+            except Exception as e:
+                summary.users_failed += 1
+                failures.append(f"{instance.instance_id} ({instance.local_username}): {e}")
+
+        if failures:
+            raise NativeSetupError("Native repair failed for some accounts:\n" + "\n".join(failures))
+
         return summary
 
     def cleanup(self) -> CleanupSummary:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bitcraft_preview"
-version = "0.4.3"
+version = "0.4.4"
 description = "A Multibox tool for Bitcraft"
 dependencies = [
     "PySide6",

--- a/tests/test_local_user_manager.py
+++ b/tests/test_local_user_manager.py
@@ -31,9 +31,10 @@ class LocalUserManagerTests(unittest.TestCase):
         with patch.object(mgr, "user_exists", return_value=False), patch(
             "bitcraft_preview.native.local_user_manager._run_command",
             side_effect=[_cp(0), _cp(0)],
-        ):
+        ), patch.object(mgr, "harden_user") as harden_mock:
             result = mgr.create_user("bitcraft1", "pw")
         self.assertEqual(result, "pw")
+        harden_mock.assert_called_once_with("bitcraft1")
 
     def test_create_user_failure_raises(self) -> None:
         mgr = LocalUserManager()
@@ -49,9 +50,36 @@ class LocalUserManagerTests(unittest.TestCase):
         with patch.object(mgr, "user_exists", return_value=False), patch(
             "bitcraft_preview.native.local_user_manager._run_command",
             return_value=_cp(1, stderr="No valid response was provided."),
-        ), patch("bitcraft_preview.native.local_user_manager._create_user_with_powershell", return_value=_cp(0)):
+        ), patch("bitcraft_preview.native.local_user_manager._create_user_with_powershell", return_value=_cp(0)), patch.object(
+            mgr, "harden_user"
+        ) as harden_mock:
             result = mgr.create_user("bitcraft1", "pw")
         self.assertEqual(result, "pw")
+        harden_mock.assert_called_once_with("bitcraft1")
+
+    def test_repair_user_resets_password_and_hardens_account(self) -> None:
+        mgr = LocalUserManager()
+        with patch.object(mgr, "user_exists", return_value=True), patch(
+            "bitcraft_preview.native.local_user_manager._run_command",
+            return_value=_cp(0),
+        ) as run_mock, patch.object(mgr, "harden_user") as harden_mock:
+            mgr.repair_user("bitcraft1", "newpw")
+
+        run_mock.assert_called_once_with(["net", "user", "bitcraft1", "newpw"])
+        harden_mock.assert_called_once_with("bitcraft1")
+
+    def test_harden_user_sets_non_expiring_enabled_account(self) -> None:
+        mgr = LocalUserManager()
+        with patch.object(mgr, "user_exists", return_value=True), patch(
+            "bitcraft_preview.native.local_user_manager._run_command",
+            return_value=_cp(0),
+        ) as run_mock, patch("bitcraft_preview.native.local_user_manager._harden_user_with_powershell", return_value=_cp(0)):
+            mgr.harden_user("bitcraft1")
+
+        calls = [call.args[0] for call in run_mock.call_args_list]
+        self.assertIn(["net", "user", "bitcraft1", "/active:yes"], calls)
+        self.assertIn(["net", "user", "bitcraft1", "/expires:never"], calls)
+        self.assertIn(["net", "user", "bitcraft1", "/times:all"], calls)
 
     def test_get_user_sid(self) -> None:
         mgr = LocalUserManager()

--- a/tests/test_local_user_manager.py
+++ b/tests/test_local_user_manager.py
@@ -76,6 +76,17 @@ class LocalUserManagerTests(unittest.TestCase):
         run_mock.assert_called_once_with(["net", "user", "bitcraft1", "newpw"])
         harden_mock.assert_called_once_with("bitcraft1")
 
+    def test_reset_password_does_not_harden_account(self) -> None:
+        mgr = LocalUserManager()
+        with patch.object(mgr, "user_exists", return_value=True), patch(
+            "bitcraft_preview.native.local_user_manager._run_command",
+            return_value=_cp(0),
+        ) as run_mock, patch.object(mgr, "harden_user") as harden_mock:
+            mgr.reset_password("bitcraft1", "newpw")
+
+        run_mock.assert_called_once_with(["net", "user", "bitcraft1", "newpw"])
+        harden_mock.assert_not_called()
+
     def test_harden_user_sets_non_expiring_enabled_account(self) -> None:
         mgr = LocalUserManager()
         with patch.object(mgr, "user_exists", return_value=True), patch(

--- a/tests/test_local_user_manager.py
+++ b/tests/test_local_user_manager.py
@@ -20,6 +20,14 @@ class LocalUserManagerTests(unittest.TestCase):
         with patch("bitcraft_preview.native.local_user_manager._run_command", return_value=_cp(2)):
             self.assertFalse(mgr.user_exists("missing"))
 
+    def test_run_command_replaces_undecodable_output(self) -> None:
+        with patch("bitcraft_preview.native.local_user_manager.subprocess.run", return_value=_cp(0)) as run_mock:
+            from bitcraft_preview.native.local_user_manager import _run_command
+
+            _run_command(["net", "user", "bitcraft1"])
+
+        self.assertEqual(run_mock.call_args.kwargs["errors"], "replace")
+
     def test_create_user_raises_if_exists(self) -> None:
         mgr = LocalUserManager()
         with patch.object(mgr, "user_exists", return_value=True):
@@ -80,6 +88,17 @@ class LocalUserManagerTests(unittest.TestCase):
         self.assertIn(["net", "user", "bitcraft1", "/active:yes"], calls)
         self.assertIn(["net", "user", "bitcraft1", "/expires:never"], calls)
         self.assertIn(["net", "user", "bitcraft1", "/times:all"], calls)
+
+    def test_powershell_harden_only_sets_local_user_flags(self) -> None:
+        from bitcraft_preview.native.local_user_manager import _harden_user_with_powershell
+
+        with patch("bitcraft_preview.native.local_user_manager._run_command", return_value=_cp(0)) as run_mock:
+            _harden_user_with_powershell("bitcraft1")
+
+        command = run_mock.call_args.args[0][-1]
+        self.assertIn("Set-LocalUser", command)
+        self.assertIn("-PasswordNeverExpires $true", command)
+        self.assertNotIn("Add-LocalGroupMember", command)
 
     def test_get_user_sid(self) -> None:
         mgr = LocalUserManager()

--- a/tests/test_native_process_control.py
+++ b/tests/test_native_process_control.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch
 
-from bitcraft_preview.native.process_control import NativeProcessController
+from bitcraft_preview.native.process_control import NativeProcessControlError, NativeProcessController
+from bitcraft_preview.native.process_launcher import ProcessLaunchError
 from bitcraft_preview.native.state_manager import NativeInstance
 
 
@@ -78,6 +79,14 @@ class _FakeLauncher:
         return 2222
 
 
+class _FailingLauncher:
+    def launch_silent(self, **kwargs):
+        raise ProcessLaunchError("[WinError 1327] Account restrictions are preventing this user from signing in", 1327)
+
+    def launch_foreground(self, **kwargs):
+        raise AssertionError("not used")
+
+
 class NativeProcessControlTests(unittest.TestCase):
     def test_is_instance_running_true_for_matching_user_and_process_name(self) -> None:
         controller = NativeProcessController(state=_FakeState())
@@ -116,6 +125,16 @@ class NativeProcessControlTests(unittest.TestCase):
         self.assertIn("-silent", kwargs["args"])
         self.assertIn("-applaunch 3454650", kwargs["args"])
         self.assertNotIn("-userchooser", kwargs["args"])
+
+    def test_launch_instance_explains_account_restriction(self) -> None:
+        controller = NativeProcessController(state=_FakeState(), launcher=_FailingLauncher())
+
+        with self.assertRaises(NativeProcessControlError) as raised:
+            controller.launch_instance("steam1")
+
+        message = str(raised.exception)
+        self.assertIn("Native Repair", message)
+        self.assertIn("bitcraft1", message)
 
     def test_open_user_chooser_uses_foreground_userchooser_flow(self) -> None:
         launcher = _FakeLauncher()

--- a/tests/test_native_setup_service.py
+++ b/tests/test_native_setup_service.py
@@ -15,6 +15,7 @@ class _FakeUserManager:
         self.deleted = []
         self.hardened = []
         self.repaired = []
+        self.reset = []
 
     def ensure_user(self, username: str, password: str | None = None):
         if username in self._created:
@@ -27,6 +28,9 @@ class _FakeUserManager:
 
     def harden_user(self, username: str) -> None:
         self.hardened.append(username)
+
+    def reset_password(self, username: str, password: str) -> None:
+        self.reset.append((username, password))
 
     def repair_user(self, username: str, password: str) -> None:
         self.repaired.append((username, password))
@@ -124,9 +128,41 @@ class NativeSetupServiceTests(unittest.TestCase):
 
             self.assertEqual(summary.users_repaired, 1)
             self.assertEqual(summary.users_failed, 0)
-            self.assertEqual(users.repaired, [("bitcraft1", "newpw")])
+            self.assertEqual(users.reset, [("bitcraft1", "newpw")])
+            self.assertEqual(users.hardened, ["bitcraft1"])
             self.assertEqual(manager.get_plain_password("steam1"), "newpw")
             self.assertEqual(manager.get_instance("steam1").local_user_sid, "S-1-5-21-bitcraft1")
+
+    def test_repair_persists_new_password_before_harden_failure(self) -> None:
+        class _FailingHardenUserManager(_FakeUserManager):
+            def harden_user(self, username: str) -> None:
+                super().harden_user(username)
+                raise RuntimeError("hardening failed")
+
+        manager = self._state()
+        users = _FailingHardenUserManager()
+        service = NativeSetupService(state=manager, user_manager=users)
+
+        with patch("bitcraft_preview.native.state_manager.protect_text", side_effect=lambda p, **_: f"ENC:{p}"), patch(
+            "bitcraft_preview.native.state_manager.unprotect_text", side_effect=lambda c: c.replace("ENC:", "", 1)
+        ):
+            manager.upsert_instance(
+                instance_id="steam1",
+                local_username="bitcraft1",
+                plain_password="oldpw",
+                instance_root=os.path.join(self._base_root, "Steam1"),
+                steam_exe_path=os.path.join(self._base_root, "Steam1", "steam.exe"),
+            )
+
+            with patch("bitcraft_preview.native.setup_service.is_admin", return_value=True), patch(
+                "bitcraft_preview.native.setup_service.LocalUserManager.generate_password", return_value="newpw"
+            ):
+                with self.assertRaisesRegex(Exception, "hardening failed"):
+                    service.repair()
+
+            self.assertEqual(users.reset, [("bitcraft1", "newpw")])
+            self.assertEqual(users.hardened, ["bitcraft1"])
+            self.assertEqual(manager.get_plain_password("steam1"), "newpw")
 
     def test_cleanup_resets_native_state_and_deletes_managed_folders(self) -> None:
         manager = self._state()

--- a/tests/test_native_setup_service.py
+++ b/tests/test_native_setup_service.py
@@ -13,6 +13,8 @@ class _FakeUserManager:
     def __init__(self) -> None:
         self._created = set()
         self.deleted = []
+        self.hardened = []
+        self.repaired = []
 
     def ensure_user(self, username: str, password: str | None = None):
         if username in self._created:
@@ -22,6 +24,12 @@ class _FakeUserManager:
 
     def get_user_sid(self, username: str) -> str:
         return f"S-1-5-21-{username}"
+
+    def harden_user(self, username: str) -> None:
+        self.hardened.append(username)
+
+    def repair_user(self, username: str, password: str) -> None:
+        self.repaired.append((username, password))
 
     def delete_user(self, username: str) -> None:
         self.deleted.append(username)
@@ -76,6 +84,7 @@ class NativeSetupServiceTests(unittest.TestCase):
 
         self.assertEqual(first.users_created, 2)
         self.assertEqual(first.users_reused, 0)
+        self.assertEqual(users.hardened, ["bitcraft1", "bitcraft2"])
         self.assertEqual(len(manager.list_instances()), 2)
 
         with patch("bitcraft_preview.native.setup_service.is_admin", return_value=True), patch(
@@ -89,7 +98,35 @@ class NativeSetupServiceTests(unittest.TestCase):
 
         self.assertEqual(second.users_created, 0)
         self.assertEqual(second.users_reused, 2)
+        self.assertEqual(users.hardened, ["bitcraft1", "bitcraft2", "bitcraft1", "bitcraft2"])
         self.assertEqual(len(manager.list_instances()), 2)
+
+    def test_repair_rotates_passwords_and_updates_state(self) -> None:
+        manager = self._state()
+        users = _FakeUserManager()
+        service = NativeSetupService(state=manager, user_manager=users)
+
+        with patch("bitcraft_preview.native.state_manager.protect_text", side_effect=lambda p, **_: f"ENC:{p}"), patch(
+            "bitcraft_preview.native.state_manager.unprotect_text", side_effect=lambda c: c.replace("ENC:", "", 1)
+        ):
+            manager.upsert_instance(
+                instance_id="steam1",
+                local_username="bitcraft1",
+                plain_password="oldpw",
+                instance_root=os.path.join(self._base_root, "Steam1"),
+                steam_exe_path=os.path.join(self._base_root, "Steam1", "steam.exe"),
+            )
+
+            with patch("bitcraft_preview.native.setup_service.is_admin", return_value=True), patch(
+                "bitcraft_preview.native.setup_service.LocalUserManager.generate_password", return_value="newpw"
+            ):
+                summary = service.repair()
+
+            self.assertEqual(summary.users_repaired, 1)
+            self.assertEqual(summary.users_failed, 0)
+            self.assertEqual(users.repaired, [("bitcraft1", "newpw")])
+            self.assertEqual(manager.get_plain_password("steam1"), "newpw")
+            self.assertEqual(manager.get_instance("steam1").local_user_sid, "S-1-5-21-bitcraft1")
 
     def test_cleanup_resets_native_state_and_deletes_managed_folders(self) -> None:
         manager = self._state()


### PR DESCRIPTION
## Summary
- add an admin-only Native Repair flow for app-managed local Windows accounts
- rotate stored native account passwords and mark accounts/passwords as non-expiring
- harden normal native setup so future accounts do not expire under local password policy
- surface WinError 1327 as a targeted Native Repair message
- bump version to 0.4.4

## Root Cause
Native accounts created through the normal `net user ... /add` path were not marked with `PasswordNeverExpires`. On machines with a finite local maximum password age, the managed `bitcraftN` passwords expired and `CreateProcessWithLogonW` failed with WinError 1327 before Steam could launch.

The first repair implementation also treated localized command output and best-effort group membership too strictly. This PR makes subprocess output decode-safe and limits the critical PowerShell hardening path to `Set-LocalUser` flags.

## Validation
- `\.venv\Scripts\python.exe -m unittest tests.test_local_user_manager tests.test_native_setup_service tests.test_native_process_control tests.test_process_launcher`
